### PR TITLE
Use system's gettext instead of compiling it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ strip = true
 
 [dependencies]
 gcd = "2.3.0"
-gettext-rs = "0.7.0"
+gettext-rs = { version = "0.7.0", features = ["gettext-system"] }
 notify-rust = { version = "4.9.0", default-features = false, features = ["d"] }
 once_cell = "1.18.0"
 serde = { version = "1.0.190", features = ["derive"] }


### PR DESCRIPTION
Since ianny targets Linux, it shouldn't compile its own gettext.